### PR TITLE
Add function to list files modified in the last 24 hours

### DIFF
--- a/system-automation-linuxmint/monitor.sh
+++ b/system-automation-linuxmint/monitor.sh
@@ -1,0 +1,6 @@
+list_recent_files() {
+    echo "Listing files modified in the last 24 hours..."
+    find . -type f -mtime -1
+}
+
+list_recent_files


### PR DESCRIPTION
**What does your new function do?**

The list_recent_files function lists all files in the current directory and its subdirectories that have been modified in the last 24 hours. It uses the find command with the -mtime -1 option to identify these recently modified files.

**Why did you choose this task to automate?**

I often need to identify files that have changed within the last day, especially when reviewing work or preparing commits. Manually checking modification times can be time-consuming and error-prone. Automating this with a simple function streamlines my workflow and reduces the chance of missing important file changes.

**What challenges did you face or lessons did you learn?**

There were no major technical challenges, but I did double-check the find syntax to ensure the time filtering was accurate (-mtime -1 selects files modified in the last 24 hours, not just "yesterday"). I also learned that this function can easily be extended to accept custom time frames, which could make it even more versatile in the future.